### PR TITLE
Keep Shared Peripheral Interrupt numbers in range

### DIFF
--- a/src/gicv3.rs
+++ b/src/gicv3.rs
@@ -49,7 +49,7 @@ impl IntId {
 
     /// Returns the interrupt ID for the given Shared Peripheral Interrupt.
     pub const fn spi(spi: u32) -> Self {
-        assert!(spi < Self::SPECIAL_START);
+        assert!(spi < Self::SPECIAL_START - Self::SPI_START);
         Self(Self::SPI_START + spi)
     }
 


### PR DESCRIPTION
Before this change, `spi` would have allowed other interrupt values to be treated as SPIs.