### PR TITLE
IROUTER registers should be 64 bits wide.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bugfixes
+
+- Changed `irouter` and `irouter_e` fields of `GICD` to use u64, to match GIC specification.
+
 ## 0.1.1
 
 ### Improvements

--- a/src/gicv3/registers.rs
+++ b/src/gicv3/registers.rs
@@ -121,10 +121,10 @@ pub struct GICD {
     pub inmr_e: [u32; 32],
     _reserved19: [u32; 2400],
     /// Interrupt routing registers.
-    pub irouter: [u32; 1975],
-    _reserved20: [u32; 9],
+    pub irouter: [u64; 988],
+    _reserved20: [u32; 8],
     /// Interrupt routing registers for extended SPI range.
-    pub irouter_e: [u32; 2048],
+    pub irouter_e: [u64; 1024],
     _reserved21: [u32; 2048],
     /// Implementation defined registers.
     pub implementation_defined2: [u32; 4084],


### PR DESCRIPTION
Fixes #16.