### PR TITLE
Move aarch64-specific sysreg macros to a submodule.

### DIFF
--- a/src/sysreg.rs
+++ b/src/sysreg.rs
@@ -5,51 +5,9 @@
 #[cfg(test)]
 #[macro_use]
 pub mod fake;
-
-#[cfg(not(test))]
-use core::arch::asm;
-
-/// Generates a safe public function named `$function_name` to read the system register `$sysreg`.
-///
-/// This should only be used for system registers which are indeed safe to read.
-#[cfg(not(test))]
-macro_rules! read_sysreg {
-    ($sysreg:ident, $function_name:ident) => {
-        pub fn $function_name() -> u64 {
-            let value;
-            // SAFETY: The caller of the macro guarantees that this system register is safe to read.
-            unsafe {
-                asm!(
-                    concat!("mrs {value}, ", stringify!($sysreg)),
-                    options(nostack),
-                    value = out(reg) value,
-                );
-            }
-            value
-        }
-    };
-}
-
-/// Generates a safe public function named `$function_name` to write to the system register
-/// `$sysreg`.
-///
-/// This should only be used for system registers which are indeed safe to write.
-#[cfg(not(test))]
-macro_rules! write_sysreg {
-    ($sysreg:ident, $function_name:ident) => {
-        pub fn $function_name(value: u64) {
-            // SAFETY: The caller of the macro guarantees that this system register is safe to
-            // write.
-            unsafe {
-                asm!(
-                    concat!("msr ", stringify!($sysreg), ", {value}"),
-                    options(nostack),
-                    value = in(reg) value,
-                );
-            }
-        }
-    };
-}
+#[cfg(all(not(test), target_arch = "aarch64"))]
+#[macro_use]
+mod aarch64;
 
 read_sysreg!(icc_iar1_el1, read_icc_iar1_el1);
 

--- a/src/sysreg/aarch64.rs
+++ b/src/sysreg/aarch64.rs
@@ -1,0 +1,43 @@
+// Copyright 2025 The arm-gic Authors.
+// This project is dual-licensed under Apache 2.0 and MIT terms.
+// See LICENSE-APACHE and LICENSE-MIT for details.
+
+/// Generates a safe public function named `$function_name` to read the system register `$sysreg`.
+///
+/// This should only be used for system registers which are indeed safe to read.
+macro_rules! read_sysreg {
+    ($sysreg:ident, $function_name:ident) => {
+        pub fn $function_name() -> u64 {
+            let value;
+            // SAFETY: The caller of the macro guarantees that this system register is safe to read.
+            unsafe {
+                core::arch::asm!(
+                    concat!("mrs {value}, ", stringify!($sysreg)),
+                    options(nostack),
+                    value = out(reg) value,
+                );
+            }
+            value
+        }
+    };
+}
+
+/// Generates a safe public function named `$function_name` to write to the system register
+/// `$sysreg`.
+///
+/// This should only be used for system registers which are indeed safe to write.
+macro_rules! write_sysreg {
+    ($sysreg:ident, $function_name:ident) => {
+        pub fn $function_name(value: u64) {
+            // SAFETY: The caller of the macro guarantees that this system register is safe to
+            // write.
+            unsafe {
+                core::arch::asm!(
+                    concat!("msr ", stringify!($sysreg), ", {value}"),
+                    options(nostack),
+                    value = in(reg) value,
+                );
+            }
+        }
+    };
+}


### PR DESCRIPTION
This helps prepare for #31.