### PR TITLE
Pass GICR base address and stride rather than array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking changes
 
 - `IntId` and `Trigger` moved to top-level module, as they are shared with GICv2 driver.
-- Added support for multiple cores. `GicV3::new` now takes an array of redistributor base addresses,
+- Added support for multiple cores. `GicV3::new` now takes the CPU count and redistributor stride,
   and various other method take a cpu index.
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugfixes
 
 - Fixed `GicV3::setup` not to write to GICD IGROUPR[0].
+- Fixed `GicV3::enable_interrupt` not to write to GICD for private interrupt IDs.
 
 ### Improvements
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```
 //! use arm_gic::{
-//!     gicv3::{SgiTarget, SingleCoreGicV3},
+//!     gicv3::{GicV3, SgiTarget},
 //!     irq_enable, IntId,
 //! };
 //!
@@ -22,7 +22,7 @@
 //! const GICR_BASE_ADDRESS: *mut u64 = 0x80A_0000 as _;
 //!
 //! // Initialise the GIC.
-//! let mut gic = unsafe { SingleCoreGicV3::new(GICD_BASE_ADDRESS, [GICR_BASE_ADDRESS]) };
+//! let mut gic = unsafe { GicV3::new(GICD_BASE_ADDRESS, GICR_BASE_ADDRESS, 1, 0x20000) };
 //! gic.setup(0);
 //!
 //! // Configure an SGI and then send it to ourself.


### PR DESCRIPTION
This avoids the generic parameter on `GicV3`.