### PR TITLE
Use safe-mmio internally in GicV3 driver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Added `AlreadyAsleep` variant to `GICRError` enum.
 - Changed `GicV3::gicd_ptr`, `GicV3::gicr_ptr` and `GicV3::sgi_ptr` to return a `UniqueMmioPointer`.
+- `GicV2` and `GicV3` now have a lifetime parameter, indicating the lifetime for which the driver
+  has exclusive access to the MMIO regions of the GIC.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@
 - Changed `GicV3::gicd_ptr`, `GicV3::gicr_ptr` and `GicV3::sgi_ptr` to return a `UniqueMmioPointer`.
 - `GicV2` and `GicV3` now have a lifetime parameter, indicating the lifetime for which the driver
   has exclusive access to the MMIO regions of the GIC.
+- `GicV2::new` and `GicV3::new` now take pointers to register struct types rather than `*mut u64`.
 
 ### Improvements
 
 - Made `IntId::is_sgi` public.
 - Made `IntId::is_*` methods const.
 - Added `GicV3::redistributor_mark_core_asleep` method.
+- Made `gicv2::registers` public.
 
 ## 0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 - Added `AlreadyAsleep` variant to `GICRError` enum.
+- Changed `GicV3::gicd_ptr`, `GicV3::gicr_ptr` and `GicV3::sgi_ptr` to return a `UniqueMmioPointer`.
 
 ### Improvements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,9 @@ name = "arm-gic"
 version = "0.2.2"
 dependencies = [
  "bitflags",
+ "safe-mmio",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]
@@ -32,6 +34,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "safe-mmio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e948e938362b65d7997a12bde3ff3112a7971e5e9a4951012a7cde5f4133a0"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -70,3 +81,23 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ categories = ["embedded", "no-std", "hardware-support"]
 
 [dependencies]
 bitflags = "2.9.0"
+safe-mmio = "0.2.4"
 thiserror = { version = "2.0.12", default-features = false }
+zerocopy = { version = "0.8.24", features = ["derive"] }
 
 [features]
 fakes = []

--- a/src/gicv2.rs
+++ b/src/gicv2.rs
@@ -138,13 +138,13 @@ impl GicV2 {
                 target_list,
             } => {
                 (intid.0 & 0xf)
-                    | match target_list_filter {
+                    | (match target_list_filter {
                         SgiTargetListFilter::CPUTargetList => 0b00,
                         SgiTargetListFilter::ForwardOthersOnly => 0b01,
                         SgiTargetListFilter::ForwardSelfOnly => 0b10,
-                    } << 24
-                    | u32::from(target_list & 0xff) << 16
-                    | 1u32 << 15
+                    } << 24)
+                    | (u32::from(target_list & 0xff) << 16)
+                    | (1u32 << 15)
             }
         };
 

--- a/src/gicv2.rs
+++ b/src/gicv2.rs
@@ -14,12 +14,12 @@ use safe_mmio::{field, field_shared, UniqueMmioPointer};
 
 /// Driver for an Arm Generic Interrupt Controller version 2.
 #[derive(Debug)]
-pub struct GicV2 {
-    gicd: UniqueMmioPointer<'static, Gicd>,
-    gicc: UniqueMmioPointer<'static, Gicc>,
+pub struct GicV2<'a> {
+    gicd: UniqueMmioPointer<'a, Gicd>,
+    gicc: UniqueMmioPointer<'a, Gicc>,
 }
 
-impl GicV2 {
+impl GicV2<'_> {
     /// Constructs a new instance of the driver for a GIC with the given distributor and
     /// controller base addresses.
     ///

--- a/src/gicv2.rs
+++ b/src/gicv2.rs
@@ -9,12 +9,14 @@ mod registers;
 pub use self::registers::Typer;
 use self::registers::{Gicc, Gicd, GicdCtlr};
 use crate::{IntId, Trigger};
+use core::ptr::NonNull;
+use safe_mmio::{field, field_shared, UniqueMmioPointer};
 
 /// Driver for an Arm Generic Interrupt Controller version 2.
 #[derive(Debug)]
 pub struct GicV2 {
-    gicd: *mut Gicd,
-    gicc: *mut Gicc,
+    gicd: UniqueMmioPointer<'static, Gicd>,
+    gicc: UniqueMmioPointer<'static, Gicc>,
 }
 
 impl GicV2 {
@@ -29,31 +31,25 @@ impl GicV2 {
     /// otherwise.
     pub unsafe fn new(gicd: *mut u64, gicc: *mut u64) -> Self {
         Self {
-            gicd: gicd as _,
-            gicc: gicc as _,
+            gicd: UniqueMmioPointer::new(NonNull::new(gicd.cast()).unwrap()),
+            gicc: UniqueMmioPointer::new(NonNull::new(gicc.cast()).unwrap()),
         }
     }
 
     /// Returns information about what the GIC implementation supports.
     pub fn typer(&self) -> Typer {
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a GIC
-        // distributor interface.
-        unsafe { (&raw mut (*self.gicd).typer).read_volatile() }
+        field_shared!(self.gicd, typer).read()
     }
 
     /// Initialises the GIC.
     pub fn setup(&mut self) {
-        // SAFETY: Both registers `self.gicd` and `self.gicc` are valid and unique pointers to
-        // the hardware interfaces provided by the user.
-        unsafe {
-            (&raw mut (*self.gicd).ctlr).write_volatile(GicdCtlr::EnableGrp1);
-            for i in 0..32 {
-                (&raw mut (*self.gicd).igroupr[i]).write_volatile(0xffffffff);
-            }
-
-            (&raw mut (*self.gicc).ctlr).write_volatile(0b1);
-            (&raw mut (*self.gicc).pmr).write_volatile(0xff);
+        field!(self.gicd, ctlr).write(GicdCtlr::EnableGrp1);
+        for i in 0..32 {
+            field!(self.gicd, igroupr).get(i).unwrap().write(0xffffffff);
         }
+
+        field!(self.gicc, ctlr).write(0b1);
+        field!(self.gicc, pmr).write(0xff);
     }
 
     /// Enables or disables the interrupt with the given ID.
@@ -62,20 +58,18 @@ impl GicV2 {
         let bit = 1 << (intid.0 % 32);
 
         if enable {
-            // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-            // GIC distributor interface.
-            unsafe {
-                (&raw mut (*self.gicd).isenabler[index]).write_volatile(bit);
-                if ((&raw const (*self.gicd).isenabler[index]).read_volatile() & bit) == 0 {
-                    return Err(());
-                }
+            field!(self.gicd, isenabler).get(index).unwrap().write(bit);
+            if (field_shared!(self.gicd, isenabler)
+                .get(index)
+                .unwrap()
+                .read()
+                & bit)
+                == 0
+            {
+                return Err(());
             }
         } else {
-            // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-            // GIC distributor interface.
-            unsafe {
-                (&raw mut (*self.gicd).icenabler[index]).write(bit);
-            }
+            field!(self.gicd, icenabler).get(index).unwrap().write(bit);
         }
         Ok(())
     }
@@ -84,17 +78,15 @@ impl GicV2 {
     pub fn enable_all_interrupts(&mut self, enable: bool) {
         for i in 0..32 {
             if enable {
-                // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers
-                // of a GIC distributor interface.
-                unsafe {
-                    (&raw mut (*self.gicd).isenabler[i]).write_volatile(0xffffffff);
-                }
+                field!(self.gicd, isenabler)
+                    .get(i)
+                    .unwrap()
+                    .write(0xffffffff);
             } else {
-                // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers
-                // of a GIC distributor interface.
-                unsafe {
-                    (&raw mut (*self.gicd).icenabler[i]).write_volatile(0xffffffff);
-                }
+                field!(self.gicd, icenabler)
+                    .get(i)
+                    .unwrap()
+                    .write(0xffffffff);
             }
         }
     }
@@ -103,10 +95,7 @@ impl GicV2 {
     ///
     /// Only interrupts with a higher priority (numerically lower) will be signalled.
     pub fn set_priority_mask(&mut self, min_priority: u8) {
-        // SAFETY: The existence of the PMR Register is guaranteed by the user.
-        unsafe {
-            (&raw mut (*self.gicc).pmr).write_volatile(min_priority as u32);
-        }
+        field!(self.gicc, pmr).write(min_priority as u32);
     }
 
     /// Sets the priority of the interrupt with the given ID.
@@ -116,11 +105,10 @@ impl GicV2 {
     pub fn set_interrupt_priority(&mut self, intid: IntId, priority: u8) {
         let idx = intid.0 as usize / 4;
         let priority = (priority as u32) << (8 * (intid.0 % 4));
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface.
-        unsafe {
-            (&raw mut (*self.gicd).ipriorityr[idx]).write_volatile(priority);
-        }
+        field!(self.gicd, ipriorityr)
+            .get(idx)
+            .unwrap()
+            .write(priority);
     }
 
     /// Configures the trigger type for the interrupt with the given ID.
@@ -128,18 +116,15 @@ impl GicV2 {
         let index = (intid.0 / 16) as usize;
         let bit = 1 << (((intid.0 % 16) * 2) + 1);
 
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface.
         // Affinity routing is not available. So instead use the icfgr register present on all
         // GICD interfaces (present as guaranteed by the user) to set trigger modes.
-        unsafe {
-            let register = (&raw mut (*self.gicd).icfgr[index]);
-            let v = register.read_volatile();
-            register.write_volatile(match trigger {
-                Trigger::Edge => v | bit,
-                Trigger::Level => v & !bit,
-            });
-        }
+        let mut icfgr = field!(self.gicd, icfgr);
+        let mut register = icfgr.get(index).unwrap();
+        let v = register.read();
+        register.write(match trigger {
+            Trigger::Edge => v | bit,
+            Trigger::Level => v & !bit,
+        });
     }
 
     /// Sends a software-generated interrupt (SGI) to the given cores.
@@ -163,21 +148,14 @@ impl GicV2 {
             }
         };
 
-        // SAFETY: As guaranteed by the user, the gicd is a valid pointer to a GIC distributor
-        // which always contains the sgir register.
-        unsafe {
-            (&raw mut (*self.gicd).sgir).write_volatile(sgi_value);
-        }
+        field!(self.gicd, sgir).write(sgi_value);
     }
 
     /// Gets the ID of the highest priority signalled interrupt, and acknowledges it.
     ///
     /// Returns `None` if there is no ptending interrupt of sufficient priority.
     pub fn get_and_acknowledge_interrupt(&mut self) -> Option<IntId> {
-        let intid = IntId(
-            // SAFETY: This memory access is guaranteed by the user passing along a valid GICD address.
-            unsafe { (&raw mut (*self.gicc).aiar).read_volatile() },
-        );
+        let intid = IntId(field!(self.gicc, aiar).read());
         if intid == IntId::SPECIAL_NONE {
             None
         } else {
@@ -188,10 +166,7 @@ impl GicV2 {
     /// Informs the interrupt controller that the CPU has completed processing the given interrupt.
     /// This drops the interrupt priority and deactivates the interrupt.
     pub fn end_interrupt(&mut self, intid: IntId) {
-        // SAFETY: The gicc is a valid pointer as guaranteed by the user. The aeoir register is always present.
-        unsafe {
-            (&raw mut (*self.gicc).aeoir).write_volatile(intid.0);
-        }
+        field!(self.gicc, aeoir).write(intid.0);
     }
 }
 

--- a/src/gicv2.rs
+++ b/src/gicv2.rs
@@ -4,7 +4,7 @@
 
 //! Driver for the Arm Generic Interrupt Controller version 2.
 
-mod registers;
+pub mod registers;
 
 pub use self::registers::Typer;
 use self::registers::{Gicc, Gicd, GicdCtlr};
@@ -29,10 +29,10 @@ impl GicV2<'_> {
     /// respectively. These regions must be mapped into the address space of the process as device
     /// memory, and not have any other aliases, either via another instance of this driver or
     /// otherwise.
-    pub unsafe fn new(gicd: *mut u64, gicc: *mut u64) -> Self {
+    pub unsafe fn new(gicd: *mut Gicd, gicc: *mut Gicc) -> Self {
         Self {
-            gicd: UniqueMmioPointer::new(NonNull::new(gicd.cast()).unwrap()),
-            gicc: UniqueMmioPointer::new(NonNull::new(gicc.cast()).unwrap()),
+            gicd: UniqueMmioPointer::new(NonNull::new(gicd).unwrap()),
+            gicc: UniqueMmioPointer::new(NonNull::new(gicc).unwrap()),
         }
     }
 

--- a/src/gicv2/registers.rs
+++ b/src/gicv2/registers.rs
@@ -1,19 +1,34 @@
 // Copyright 2025 The arm-gic Authors.
 // This project is dual-licensed under Apache 2.0 and MIT terms.
 // See LICENSE-APACHE and LICENSE-MIT for details.
+
 use bitflags::bitflags;
+use core::fmt::{self, Debug, Formatter};
+use safe_mmio::fields::{ReadOnly, ReadPure, ReadPureWrite, WriteOnly};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+#[derive(Clone, Copy, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+#[repr(transparent)]
+pub struct GicdCtlr(u32);
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    pub struct GicdCtlr: u32 {
+    impl GicdCtlr: u32 {
         const EnableGrp1 = 1 << 1;
         const EnableGrp0 = 1 << 0;
     }
 }
 
+impl Debug for GicdCtlr {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "GicdCtlr(")?;
+        bitflags::parser::to_writer(self, &mut *f)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
 /// GICv2 type register value.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
 #[repr(transparent)]
 pub struct Typer(u32);
 
@@ -43,44 +58,44 @@ impl Typer {
 #[repr(C, align(8))]
 pub struct Gicd {
     /// Distributor Control Register
-    pub ctlr: GicdCtlr,
+    pub ctlr: ReadPureWrite<GicdCtlr>,
     /// Interrupt Controller Type Register
-    pub typer: Typer,
+    pub typer: ReadPure<Typer>,
     /// Distributor Implementer Identification Register.
-    pub iidr: u32,
+    pub iidr: ReadPure<u32>,
     _reserved_0: [u32; 0x1D],
     /// Interrupt Group Registers
-    pub igroupr: [u32; 0x20],
+    pub igroupr: [ReadPureWrite<u32>; 0x20],
     /// Interrupt Set-Enable Registers.
-    pub isenabler: [u32; 0x20],
+    pub isenabler: [ReadPureWrite<u32>; 0x20],
     /// Interrupt Clear-Enable Registers.
-    pub icenabler: [u32; 0x20],
+    pub icenabler: [ReadPureWrite<u32>; 0x20],
     /// Interrupt Set-Pending Registers.
-    pub ispendr: [u32; 0x20],
+    pub ispendr: [ReadPureWrite<u32>; 0x20],
     /// Interrupt Clear-Pending Registers.
-    pub icpendr: [u32; 0x20],
+    pub icpendr: [ReadPureWrite<u32>; 0x20],
     /// Interrupt Set-Active Registers.
-    pub isactiver: [u32; 0x20],
+    pub isactiver: [ReadPureWrite<u32>; 0x20],
     /// Interrupt Clear-Active Registers.
-    pub icactiver: [u32; 0x20],
+    pub icactiver: [ReadPureWrite<u32>; 0x20],
     /// Interrupt Priority Registers.
-    pub ipriorityr: [u32; 0x100],
+    pub ipriorityr: [ReadPureWrite<u32>; 0x100],
     /// Interrupt Processor Targets Registers.
     pub itargetsr: [u32; 0x100],
     /// Interrupt Configuration Registers.
-    pub icfgr: [u32; 0x40],
+    pub icfgr: [ReadPureWrite<u32>; 0x40],
     _reserved_1: [u32; 0x80],
     /// Software Generated Interrupt Register.
-    pub sgir: u32,
+    pub sgir: WriteOnly<u32>,
 }
 
 /// GIC CPU interface registers.
 #[repr(C, align(8))]
 pub struct Gicc {
     /// CPU Interface Control Register.
-    pub ctlr: u32,
+    pub ctlr: ReadPureWrite<u32>,
     /// Interrupt Priority Mask Register.
-    pub pmr: u32,
+    pub pmr: ReadPureWrite<u32>,
     /// Binary Point Register.
     pub bpr: u32,
     /// Interrupt Acknowledge Register.
@@ -93,10 +108,10 @@ pub struct Gicc {
     pub hppir: u32,
     /// Aliased Binary Point Register
     pub abpr: u32,
-    /// Aliased Interrupt Acknwoledge Register
-    pub aiar: u32,
+    /// Aliased Interrupt Acknowledge Register
+    pub aiar: ReadOnly<u32>,
     /// Aliased End of Interrupt Register
-    pub aeoir: u32,
+    pub aeoir: WriteOnly<u32>,
     /// Aliased Highest Priority Pending Interrupt Register
     pub ahppir: u32,
     _reserved_0: [u32; 0x34],

--- a/src/gicv3.rs
+++ b/src/gicv3.rs
@@ -12,8 +12,10 @@ use crate::sysreg::{
     write_icc_igrpen1_el1, write_icc_pmr_el1, write_icc_sgi1r_el1, write_icc_sre_el1,
 };
 use crate::{IntId, Trigger};
-use core::hint::spin_loop;
+use core::{hint::spin_loop, ptr::NonNull};
 use registers::Typer;
+use safe_mmio::fields::ReadPureWrite;
+use safe_mmio::{field, field_shared, UniqueMmioPointer};
 use thiserror::Error;
 
 /// The offset in bytes from `RD_base` to `SGI_base`.
@@ -33,7 +35,7 @@ pub enum GICRError {
 /// # Safety
 ///
 /// The caller must ensure that `registers` is a valid pointer for volatile reads and writes.
-unsafe fn modify_bit(registers: *mut [u32], nth: usize, set_bit: bool) {
+unsafe fn modify_bit(registers: *mut [ReadPureWrite<u32>], nth: usize, set_bit: bool) {
     let reg_num: usize = nth / 32;
 
     let bit_num: usize = nth % 32;
@@ -44,7 +46,7 @@ unsafe fn modify_bit(registers: *mut [u32], nth: usize, set_bit: bool) {
     // and `reg_num` does not exceed `*registers` length.
     unsafe {
         let reg_ptr = &raw mut (*registers)[reg_num];
-        let old_value = reg_ptr.read_volatile();
+        let old_value = reg_ptr.read_volatile().0;
 
         let new_value: u32 = if set_bit {
             old_value | bit_mask
@@ -52,7 +54,7 @@ unsafe fn modify_bit(registers: *mut [u32], nth: usize, set_bit: bool) {
             old_value & !bit_mask
         };
 
-        reg_ptr.write_volatile(new_value);
+        reg_ptr.write_volatile(ReadPureWrite(new_value));
     }
 }
 
@@ -62,7 +64,7 @@ unsafe fn modify_bit(registers: *mut [u32], nth: usize, set_bit: bool) {
 ///
 /// The caller must ensure that `registers` is a valid
 /// pointer for volatile reads and writes.
-unsafe fn set_bit(registers: *mut [u32], nth: usize) {
+unsafe fn set_bit(registers: *mut [ReadPureWrite<u32>], nth: usize) {
     modify_bit(registers, nth, true);
 }
 
@@ -72,14 +74,14 @@ unsafe fn set_bit(registers: *mut [u32], nth: usize) {
 ///
 /// The caller must ensure that `registers` is a valid
 /// pointer for volatile reads and writes.
-unsafe fn clear_bit(registers: *mut [u32], nth: usize) {
+unsafe fn clear_bit(registers: *mut [ReadPureWrite<u32>], nth: usize) {
     modify_bit(registers, nth, false);
 }
 
 /// Driver for an Arm Generic Interrupt Controller version 3 (or 4).
 #[derive(Debug)]
 pub struct GicV3 {
-    gicd: *mut Gicd,
+    gicd: UniqueMmioPointer<'static, Gicd>,
     gicr_base: *mut Gicr,
     /// The number of CPU cores, and hence redistributors.
     cpu_count: usize,
@@ -105,7 +107,9 @@ impl GicV3 {
     ) -> Self {
         assert_eq!(gicr_stride % 0x20000, 0);
         Self {
-            gicd: gicd as _,
+            // SAFETY: Our caller promised that `gicd` is a valid and unique pointer to a GIC
+            // distributor.
+            gicd: unsafe { UniqueMmioPointer::new(NonNull::new(gicd.cast()).unwrap()) },
             gicr_base: gicr_base as _,
             cpu_count,
             gicr_stride,
@@ -141,25 +145,19 @@ impl GicV3 {
     pub fn setup(&mut self, cpu: usize) {
         self.init_cpu(cpu);
 
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface.
-        unsafe {
-            // Enable affinity routing and non-secure group 1 interrupts.
-            (&raw mut (*self.gicd).ctlr).write_volatile(GicdCtlr::ARE_S | GicdCtlr::EnableGrp1NS);
-        }
+        // Enable affinity routing and non-secure group 1 interrupts.
+        field!(self.gicd, ctlr).write(GicdCtlr::ARE_S | GicdCtlr::EnableGrp1NS);
 
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
-        // redistributor interface.
-        unsafe {
+        {
             // Put all SGIs and PPIs into non-secure group 1.
             for cpu in 0..self.cpu_count {
-                (&raw mut (*self.sgi_ptr(cpu)).igroupr0).write_volatile(0xffffffff);
+                let mut sgi = self.sgi_ptr(cpu);
+                field!(sgi, igroupr0).write(0xffffffff);
             }
-            // Put all SPIs into non-secure group 1.
-            for i in 1..32 {
-                (&raw mut (*self.gicd).igroupr[i]).write_volatile(0xffffffff);
-            }
+        }
+        // Put all SPIs into non-secure group 1.
+        for i in 1..32 {
+            field!(self.gicd, igroupr).get(i).unwrap().write(0xffffffff);
         }
 
         // Enable group 1 for the current security state.
@@ -181,22 +179,19 @@ impl GicV3 {
     /// If it is an SGI or PPI then the CPU core on which to enable it must also be specified;
     /// otherwise this is ignored and may be `None`.
     pub fn enable_interrupt(&mut self, intid: IntId, cpu: Option<usize>, enable: bool) {
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
-        // redistributor interface.
-        let (isenabler, icenabler): (*mut [u32], *mut [u32]) = unsafe {
+        let (isenabler, icenabler): (*mut [ReadPureWrite<u32>], *mut [ReadPureWrite<u32>]) =
             if intid.is_private() {
+                let mut sgi = self.sgi_ptr(cpu.unwrap());
                 (
-                    &raw mut (*self.sgi_ptr(cpu.unwrap())).isenabler0 as *mut [u32; 1],
-                    &raw mut (*self.sgi_ptr(cpu.unwrap())).icenabler0 as *mut [u32; 1],
+                    field!(sgi, isenabler0).ptr_mut() as *mut [ReadPureWrite<u32>; 1],
+                    field!(sgi, icenabler0).ptr_mut() as *mut [ReadPureWrite<u32>; 1],
                 )
             } else {
                 (
-                    &raw mut (*self.gicd).isenabler,
-                    &raw mut (*self.gicd).icenabler,
+                    field!(self.gicd, isenabler).ptr_mut(),
+                    field!(self.gicd, icenabler).ptr_mut(),
                 )
-            }
-        };
+            };
 
         // SAFETY: We know that `isenabler` and `icenabler` are valid and unique pointers
         // to the registers of GIC distributor or redistributor interface.
@@ -212,25 +207,24 @@ impl GicV3 {
     /// Enables or disables all interrupts on all CPU cores.
     pub fn enable_all_interrupts(&mut self, enable: bool) {
         for i in 1..32 {
-            // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers
-            // of a GIC distributor interface.
-            unsafe {
-                if enable {
-                    (&raw mut (*self.gicd).isenabler[i]).write_volatile(0xffffffff);
-                } else {
-                    (&raw mut (*self.gicd).icenabler[i]).write_volatile(0xffffffff);
-                }
+            if enable {
+                field!(self.gicd, isenabler)
+                    .get(i)
+                    .unwrap()
+                    .write(0xffffffff);
+            } else {
+                field!(self.gicd, icenabler)
+                    .get(i)
+                    .unwrap()
+                    .write(0xffffffff);
             }
         }
         for cpu in 0..self.cpu_count {
-            // SAFETY: We know that `self.sgis` are valid and unique pointers to the SGI and PPI
-            // registers of a GIC redistributor interface.
-            unsafe {
-                if enable {
-                    (&raw mut (*self.sgi_ptr(cpu)).isenabler0).write_volatile(0xffffffff);
-                } else {
-                    (&raw mut (*self.sgi_ptr(cpu)).icenabler0).write_volatile(0xffffffff);
-                }
+            let mut sgi = self.sgi_ptr(cpu);
+            if enable {
+                field!(sgi, isenabler0).write(0xffffffff);
+            } else {
+                field!(sgi, icenabler0).write(0xffffffff);
             }
         }
     }
@@ -247,17 +241,18 @@ impl GicV3 {
     /// Note that lower numbers correspond to higher priorities; i.e. 0 is the highest priority, and
     /// 255 is the lowest.
     pub fn set_interrupt_priority(&mut self, intid: IntId, cpu: Option<usize>, priority: u8) {
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
-        // redistributor interface.
-        unsafe {
-            // Affinity routing is enabled, so use the GICR for SGIs and PPIs.
-            if intid.is_private() {
-                (&raw mut (*self.sgi_ptr(cpu.unwrap())).ipriorityr[intid.0 as usize])
-                    .write_volatile(priority);
-            } else {
-                (&raw mut (*self.gicd).ipriorityr[intid.0 as usize]).write_volatile(priority);
-            }
+        // Affinity routing is enabled, so use the GICR for SGIs and PPIs.
+        if intid.is_private() {
+            let mut sgi = self.sgi_ptr(cpu.unwrap());
+            field!(sgi, ipriorityr)
+                .get(intid.0 as usize)
+                .unwrap()
+                .write(priority);
+        } else {
+            field!(self.gicd, ipriorityr)
+                .get(intid.0 as usize)
+                .unwrap()
+                .write(priority);
         }
     }
 
@@ -266,45 +261,42 @@ impl GicV3 {
         let index = (intid.0 / 16) as usize;
         let bit = 1 << (((intid.0 % 16) * 2) + 1);
 
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
-        // redistributor interface.
-        unsafe {
-            // Affinity routing is enabled, so use the GICR for SGIs and PPIs.
-            let register = if intid.is_private() {
-                (&raw mut (*self.sgi_ptr(cpu.unwrap())).icfgr[index])
-            } else {
-                (&raw mut (*self.gicd).icfgr[index])
-            };
-            let v = register.read_volatile();
-            register.write_volatile(match trigger {
+        // Affinity routing is enabled, so use the GICR for SGIs and PPIs.
+        if intid.is_private() {
+            let mut sgi = self.sgi_ptr(cpu.unwrap());
+            let mut icfgr = field!(sgi, icfgr);
+            let mut register = icfgr.get(index).unwrap();
+            let v = register.read();
+            register.write(match trigger {
                 Trigger::Edge => v | bit,
                 Trigger::Level => v & !bit,
             });
-        }
+        } else {
+            let mut icfgr = field!(self.gicd, icfgr);
+            let mut register = icfgr.get(index).unwrap();
+            let v = register.read();
+            register.write(match trigger {
+                Trigger::Edge => v | bit,
+                Trigger::Level => v & !bit,
+            });
+        };
     }
 
     /// Assigns the interrupt with id `intid` to interrupt group `group`.
     pub fn set_group(&mut self, intid: IntId, cpu: Option<usize>, group: Group) {
-        // FIXME: For now we assume that we are running a single-core system.
-        // so there's just one GICR frame and one SGI configuration.
-
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface, and `self.sgi` to the SGI and PPI registers of a GIC
-        // redistributor interface.
-        let (igroupr, igrpmodr): (*mut [u32], *mut [u32]) = unsafe {
+        let (igroupr, igrpmodr): (*mut [ReadPureWrite<u32>], *mut [ReadPureWrite<u32>]) =
             if intid.is_private() {
+                let mut sgi = self.sgi_ptr(cpu.unwrap());
                 (
-                    &raw mut (*self.sgi_ptr(cpu.unwrap())).igroupr0 as *mut [u32; 1],
-                    &raw mut (*self.sgi_ptr(cpu.unwrap())).igrpmodr0 as *mut [u32; 1],
+                    field!(sgi, igroupr0).ptr_mut() as *mut [ReadPureWrite<u32>; 1],
+                    field!(sgi, igrpmodr0).ptr_mut() as *mut [ReadPureWrite<u32>; 1],
                 )
             } else {
                 (
-                    &raw mut (*self.gicd).igroupr,
-                    &raw mut (*self.gicd).igrpmodr,
+                    field!(self.gicd, igroupr).ptr_mut(),
+                    field!(self.gicd, igrpmodr).ptr_mut(),
                 )
-            }
-        };
+            };
 
         // SAFETY: We know that `igroupr` and `igrpmodr` are valid and unique pointers
         // to the registers of GIC distributor or redistributor interface.
@@ -370,55 +362,63 @@ impl GicV3 {
 
     /// Returns information about what the GIC implementation supports.
     pub fn typer(&self) -> Typer {
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a GIC
-        // distributor interface.
-        unsafe { (&raw mut (*self.gicd).typer).read_volatile() }
+        field_shared!(self.gicd, typer).read()
     }
 
-    /// Returns a raw pointer to the GIC distributor registers.
+    /// Returns a pointer to the GIC distributor registers.
     ///
     /// This may be used to read and write the registers directly for functionality not yet
     /// supported by this driver.
-    pub fn gicd_ptr(&mut self) -> *mut Gicd {
-        self.gicd
+    pub fn gicd_ptr(&mut self) -> UniqueMmioPointer<Gicd> {
+        self.gicd.reborrow()
     }
 
-    /// Returns a raw pointer to the GIC redistributor registers.
+    /// Returns a pointer to the GIC redistributor registers.
     ///
     /// This may be used to read and write the registers directly for functionality not yet
     /// supported by this driver.
-    pub fn gicr_ptr(&mut self, cpu: usize) -> *mut Gicr {
+    pub fn gicr_ptr(&mut self, cpu: usize) -> UniqueMmioPointer<Gicr> {
         assert!(cpu < self.cpu_count);
-        self.gicr_base.wrapping_byte_add(cpu * self.gicr_stride)
+        // SAFETY: The caller of `GicV3::new` promised that `gicr_base` and `gicr_stride` were valid
+        // and there are no aliases.
+        unsafe {
+            UniqueMmioPointer::new(
+                NonNull::new(self.gicr_base.wrapping_byte_add(cpu * self.gicr_stride)).unwrap(),
+            )
+        }
     }
 
-    /// Returns a raw pointer to the GIC redistributor SGI and PPI registers.
+    /// Returns a pointer to the GIC redistributor SGI and PPI registers.
     ///
     /// This may be used to read and write the registers directly for functionality not yet
     /// supported by this driver.
-    pub fn sgi_ptr(&mut self, cpu: usize) -> *mut Sgi {
-        self.gicr_ptr(cpu).wrapping_byte_add(SGI_OFFSET).cast()
+    pub fn sgi_ptr(&mut self, cpu: usize) -> UniqueMmioPointer<Sgi> {
+        assert!(cpu < self.cpu_count);
+        // SAFETY: The caller of `GicV3::new` promised that `gicr_base` and `gicr_stride` were valid
+        // and there are no aliases.
+        unsafe {
+            UniqueMmioPointer::new(
+                NonNull::new(
+                    self.gicr_base
+                        .wrapping_byte_add(cpu * self.gicr_stride + SGI_OFFSET)
+                        .cast(),
+                )
+                .unwrap(),
+            )
+        }
     }
 
-    fn gicd_barrier(&mut self) {
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface.
-        unsafe {
-            while (&raw const (*self.gicd).ctlr)
-                .read_volatile()
-                .contains(GicdCtlr::RWP)
-            {}
-        }
+    fn gicd_barrier(&self) {
+        while field_shared!(self.gicd, ctlr)
+            .read()
+            .contains(GicdCtlr::RWP)
+        {}
     }
 
     fn gicd_modify_control(&mut self, f: impl FnOnce(GicdCtlr) -> GicdCtlr) {
-        // SAFETY: We know that `self.gicd` is a valid and unique pointer to the registers of a
-        // GIC distributor interface.
-        unsafe {
-            let gicd_ctlr = (&raw mut (*self.gicd).ctlr).read_volatile();
+        let gicd_ctlr = field_shared!(self.gicd, ctlr).read();
 
-            (&raw mut (*self.gicd).ctlr).write_volatile(f(gicd_ctlr));
-        }
+        field!(self.gicd, ctlr).write(f(gicd_ctlr));
 
         self.gicd_barrier();
     }
@@ -435,74 +435,58 @@ impl GicV3 {
 
     /// Blocks until register write for the current Security state is no longer in progress.
     pub fn gicr_barrier(&mut self, cpu: usize) {
-        // SAFETY: We know that `self.sgi` is a valid and unique pointer to the SGI and PPI
-        // registers of a GIC redistributor interface.
-        unsafe {
-            while (&raw const (*self.gicr_ptr(cpu)).ctlr)
-                .read_volatile()
-                .contains(GicrCtlr::RWP)
-            {}
-        }
+        let gicr = self.gicr_ptr(cpu);
+        while field_shared!(gicr, ctlr).read().contains(GicrCtlr::RWP) {}
     }
 
     /// Informs the GIC redistributor that the core has awakened.
     ///
     /// Blocks until `GICR_WAKER.ChildrenAsleep` is cleared.
     pub fn redistributor_mark_core_awake(&mut self, cpu: usize) -> Result<(), GICRError> {
-        // SAFETY: We know that `self.gicr` is a valid and unique pointer to
-        // the GIC redistributor interface.
-        unsafe {
-            let mut gicr_waker = (&raw const (*self.gicr_ptr(cpu)).waker).read_volatile();
+        let mut gicr = self.gicr_ptr(cpu);
+        let mut waker = field!(gicr, waker);
+        let mut gicr_waker = waker.read();
 
-            // The WAKER_PS_BIT should be changed to 0 only when WAKER_CA_BIT is 1.
-            if !gicr_waker.contains(Waker::CHILDREN_ASLEEP) {
-                return Err(GICRError::AlreadyAwake);
-            }
-
-            // Mark the connected core as awake.
-            gicr_waker -= Waker::PROCESSOR_SLEEP;
-            (&raw mut (*self.gicr_ptr(cpu)).waker).write_volatile(gicr_waker);
-
-            // Wait till the WAKER_CA_BIT changes to 0.
-            while (&raw const (*self.gicr_ptr(cpu)).waker)
-                .read_volatile()
-                .contains(Waker::CHILDREN_ASLEEP)
-            {
-                spin_loop();
-            }
-
-            Ok(())
+        // The WAKER_PS_BIT should be changed to 0 only when WAKER_CA_BIT is 1.
+        if !gicr_waker.contains(Waker::CHILDREN_ASLEEP) {
+            return Err(GICRError::AlreadyAwake);
         }
+
+        // Mark the connected core as awake.
+        gicr_waker -= Waker::PROCESSOR_SLEEP;
+        waker.write(gicr_waker);
+
+        // Wait till the WAKER_CA_BIT changes to 0.
+        while waker.read().contains(Waker::CHILDREN_ASLEEP) {
+            spin_loop();
+        }
+
+        Ok(())
     }
 
     /// Informs the GIC redistributor that the core is asleep.
     ///
     /// Blocks until `GICR_WAKER.ChildrenAsleep` is set.
     pub fn redistributor_mark_core_asleep(&mut self, cpu: usize) -> Result<(), GICRError> {
-        // SAFETY: We know that `self.gicr` is a valid and unique pointer to
-        // the GIC redistributor interface.
-        unsafe {
-            let mut gicr_waker = (&raw const (*self.gicr_ptr(cpu)).waker).read_volatile();
+        let mut gicr = self.gicr_ptr(cpu);
+        let mut waker = field!(gicr, waker);
+        let mut gicr_waker = waker.read();
 
-            // The WAKER_PS_BIT should be changed to 1 only when WAKER_CA_BIT is 0.
-            if gicr_waker.contains(Waker::CHILDREN_ASLEEP) {
-                return Err(GICRError::AlreadyAsleep);
-            }
-
-            // Mark the connected core as asleep.
-            gicr_waker |= Waker::PROCESSOR_SLEEP;
-            (&raw mut (*self.gicr_ptr(cpu)).waker).write_volatile(gicr_waker);
-
-            // Wait till the WAKER_CA_BIT changes to 1.
-            while !(&raw const (*self.gicr_ptr(cpu)).waker)
-                .read_volatile()
-                .contains(Waker::CHILDREN_ASLEEP)
-            {
-                spin_loop();
-            }
-
-            Ok(())
+        // The WAKER_PS_BIT should be changed to 1 only when WAKER_CA_BIT is 0.
+        if gicr_waker.contains(Waker::CHILDREN_ASLEEP) {
+            return Err(GICRError::AlreadyAsleep);
         }
+
+        // Mark the connected core as asleep.
+        gicr_waker |= Waker::PROCESSOR_SLEEP;
+        waker.write(gicr_waker);
+
+        // Wait till the WAKER_CA_BIT changes to 1.
+        while !waker.read().contains(Waker::CHILDREN_ASLEEP) {
+            spin_loop();
+        }
+
+        Ok(())
     }
 }
 

--- a/src/gicv3.rs
+++ b/src/gicv3.rs
@@ -61,8 +61,8 @@ fn clear_bit(registers: UniqueMmioPointer<[ReadPureWrite<u32>]>, nth: usize) {
 
 /// Driver for an Arm Generic Interrupt Controller version 3 (or 4).
 #[derive(Debug)]
-pub struct GicV3 {
-    gicd: UniqueMmioPointer<'static, Gicd>,
+pub struct GicV3<'a> {
+    gicd: UniqueMmioPointer<'a, Gicd>,
     gicr_base: *mut Gicr,
     /// The number of CPU cores, and hence redistributors.
     cpu_count: usize,
@@ -70,7 +70,7 @@ pub struct GicV3 {
     gicr_stride: usize,
 }
 
-impl GicV3 {
+impl GicV3<'_> {
     /// Constructs a new instance of the driver for a GIC with the given distributor and
     /// redistributor base addresses.
     ///
@@ -462,10 +462,10 @@ impl GicV3 {
 }
 
 // SAFETY: The GIC interface can be accessed from any CPU core.
-unsafe impl Send for GicV3 {}
+unsafe impl Send for GicV3<'_> {}
 
 // SAFETY: Any operations which change state require `&mut GicV3`, so `&GicV3` is fine to share.
-unsafe impl Sync for GicV3 {}
+unsafe impl Sync for GicV3<'_> {}
 
 /// The group configuration for an interrupt.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/src/gicv3.rs
+++ b/src/gicv3.rs
@@ -78,8 +78,8 @@ impl GicV3<'_> {
     /// memory, and not have any other aliases, either via another instance of this driver or
     /// otherwise.
     pub unsafe fn new(
-        gicd: *mut u64,
-        gicr_base: *mut u64,
+        gicd: *mut Gicd,
+        gicr_base: *mut GicrSgi,
         cpu_count: usize,
         gicr_stride: usize,
     ) -> Self {
@@ -87,8 +87,8 @@ impl GicV3<'_> {
         Self {
             // SAFETY: Our caller promised that `gicd` is a valid and unique pointer to a GIC
             // distributor.
-            gicd: unsafe { UniqueMmioPointer::new(NonNull::new(gicd.cast()).unwrap()) },
-            gicr_base: gicr_base as _,
+            gicd: unsafe { UniqueMmioPointer::new(NonNull::new(gicd).unwrap()) },
+            gicr_base: gicr_base,
             cpu_count,
             gicr_stride,
         }

--- a/src/gicv3/registers.rs
+++ b/src/gicv3/registers.rs
@@ -6,12 +6,19 @@
 
 use super::IntId;
 use bitflags::bitflags;
-use core::cmp::min;
+use core::{
+    cmp::min,
+    fmt::{self, Debug, Formatter},
+};
+use safe_mmio::fields::{ReadPure, ReadPureWrite};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+pub struct GicdCtlr(u32);
 
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-    pub struct GicdCtlr: u32 {
+    impl GicdCtlr: u32 {
         const RWP = 1 << 31;
         const nASSGIreq = 1 << 8;
         const E1NWF = 1 << 7;
@@ -24,10 +31,20 @@ bitflags! {
     }
 }
 
+impl Debug for GicdCtlr {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "GicdCtlr(")?;
+        bitflags::parser::to_writer(self, &mut *f)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+pub struct GicrCtlr(u32);
+
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-    pub struct GicrCtlr: u32 {
+    impl GicrCtlr: u32 {
         const UWP = 1 << 31;
         const DPG1S = 1 << 26;
         const DPG1NS = 1 << 25;
@@ -39,8 +56,17 @@ bitflags! {
     }
 }
 
+impl Debug for GicrCtlr {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "GicrCtlr(")?;
+        bitflags::parser::to_writer(self, &mut *f)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
+
 /// Interrupt controller type register value.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
 #[repr(transparent)]
 pub struct Typer(u32);
 
@@ -143,9 +169,9 @@ pub enum RangeSelectorSupport {
 #[repr(C, align(8))]
 pub struct Gicd {
     /// Distributor control register.
-    pub ctlr: GicdCtlr,
+    pub ctlr: ReadPureWrite<GicdCtlr>,
     /// Interrupt controller type register.
-    pub typer: Typer,
+    pub typer: ReadPure<Typer>,
     /// Distributor implementer identification register.
     pub iidr: u32,
     /// Interrupt controller type register 2.
@@ -168,11 +194,11 @@ pub struct Gicd {
     pub clrspi_sr: u32,
     _reserved4: [u32; 9],
     /// Interrupt group registers.
-    pub igroupr: [u32; 32],
+    pub igroupr: [ReadPureWrite<u32>; 32],
     /// Interrupt set-enable registers.
-    pub isenabler: [u32; 32],
+    pub isenabler: [ReadPureWrite<u32>; 32],
     /// Interrupt clear-enable registers.
-    pub icenabler: [u32; 32],
+    pub icenabler: [ReadPureWrite<u32>; 32],
     /// Interrupt set-pending registers.
     pub ispendr: [u32; 32],
     /// Interrupt clear-pending registers.
@@ -182,13 +208,13 @@ pub struct Gicd {
     /// Interrupt clear-active registers.
     pub icactiver: [u32; 32],
     /// Interrupt priority registers.
-    pub ipriorityr: [u8; 1024],
+    pub ipriorityr: [ReadPureWrite<u8>; 1024],
     /// Interrupt processor targets registers.
     pub itargetsr: [u32; 256],
     /// Interrupt configuration registers.
-    pub icfgr: [u32; 64],
+    pub icfgr: [ReadPureWrite<u32>; 64],
     /// Interrupt group modifier registers.
-    pub igrpmodr: [u32; 32],
+    pub igrpmodr: [ReadPureWrite<u32>; 32],
     _reserved5: [u32; 32],
     /// Non-secure access control registers.
     pub nsacr: [u32; 64],
@@ -203,13 +229,13 @@ pub struct Gicd {
     /// Non-maskable interrupt registers.
     pub inmir: [u32; 32],
     /// Interrupt group registers for extended SPI range.
-    pub igroupr_e: [u32; 32],
+    pub igroupr_e: [ReadPureWrite<u32>; 32],
     _reserved8: [u32; 96],
     /// Interrupt set-enable registers for extended SPI range.
-    pub isenabler_e: [u32; 32],
+    pub isenabler_e: [ReadPureWrite<u32>; 32],
     _reserved9: [u32; 96],
     /// Interrupt clear-enable registers for extended SPI range.
-    pub icenabler_e: [u32; 32],
+    pub icenabler_e: [ReadPureWrite<u32>; 32],
     _reserved10: [u32; 96],
     /// Interrupt set-pending registers for extended SPI range.
     pub ispendr_e: [u32; 32],
@@ -224,13 +250,13 @@ pub struct Gicd {
     pub icactive_e: [u32; 32],
     _reserved14: [u32; 224],
     /// Interrupt priority registers for extended SPI range.
-    pub ipriorityr_e: [u8; 1024],
+    pub ipriorityr_e: [ReadPureWrite<u8>; 1024],
     _reserved15: [u32; 768],
     /// Extended SPI configuration registers.
-    pub icfgr_e: [u32; 64],
+    pub icfgr_e: [ReadPureWrite<u32>; 64],
     _reserved16: [u32; 192],
     /// Interrupt group modifier registers for extended SPI range.
-    pub igrpmodr_e: [u32; 32],
+    pub igrpmodr_e: [ReadPureWrite<u32>; 32],
     _reserved17: [u32; 96],
     /// Non-secure access control registers for extended SPI range.
     pub nsacr_e: [u32; 32],
@@ -250,10 +276,20 @@ pub struct Gicd {
     pub id_registers: [u32; 12],
 }
 
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, FromBytes, Immutable, IntoBytes, KnownLayout, PartialEq)]
+pub struct Waker(u32);
+
+impl Debug for Waker {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "Waker(")?;
+        bitflags::parser::to_writer(self, &mut *f)?;
+        write!(f, ")")?;
+        Ok(())
+    }
+}
 bitflags! {
-    #[repr(transparent)]
-    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-    pub struct Waker: u32 {
+    impl Waker: u32 {
         const CHILDREN_ASLEEP = 1 << 2;
         const PROCESSOR_SLEEP = 1 << 1;
     }
@@ -263,7 +299,7 @@ bitflags! {
 #[repr(C, align(8))]
 pub struct Gicr {
     /// Redistributor control register.
-    pub ctlr: GicrCtlr,
+    pub ctlr: ReadPureWrite<GicrCtlr>,
     /// Implementer identification register.
     pub iidr: u32,
     /// Redistributor type register.
@@ -271,7 +307,7 @@ pub struct Gicr {
     /// Error reporting status register.
     pub statusr: u32,
     /// Redistributor wake register.
-    pub waker: Waker,
+    pub waker: ReadPureWrite<Waker>,
     /// Report maximum PARTID and PMG register.
     pub mpamidr: u32,
     /// Set PARTID and PMG register.
@@ -314,19 +350,19 @@ pub struct Gicr {
 pub struct Sgi {
     _reserved0: [u32; 32],
     /// Interrupt group register 0.
-    pub igroupr0: u32,
+    pub igroupr0: ReadPureWrite<u32>,
     /// Interrupt group registers for extended PPI range.
-    pub igroupr_e: [u32; 2],
+    pub igroupr_e: [ReadPureWrite<u32>; 2],
     _reserved1: [u32; 29],
     /// Interrupt set-enable register 0.
-    pub isenabler0: u32,
+    pub isenabler0: ReadPureWrite<u32>,
     /// Interrupt set-enable registers for extended PPI range.
-    pub isenabler_e: [u32; 2],
+    pub isenabler_e: [ReadPureWrite<u32>; 2],
     _reserved2: [u32; 29],
     /// Interrupt clear-enable register 0.
-    pub icenabler0: u32,
+    pub icenabler0: ReadPureWrite<u32>,
     /// Interrupt clear-enable registers for extended PPI range.
-    pub icenabler_e: [u32; 2],
+    pub icenabler_e: [ReadPureWrite<u32>; 2],
     _reserved3: [u32; 29],
     /// Interrupt set-pending register 0.
     pub ispendr0: u32,
@@ -349,18 +385,18 @@ pub struct Sgi {
     pub icactive_e: [u32; 2],
     _reserved7: [u32; 29],
     /// Interrupt priority registers.
-    pub ipriorityr: [u8; 32],
+    pub ipriorityr: [ReadPureWrite<u8>; 32],
     /// Interrupt priority registers for extended PPI range.
-    pub ipriorityr_e: [u8; 64],
+    pub ipriorityr_e: [ReadPureWrite<u8>; 64],
     _reserved8: [u32; 488],
     /// SGI configuration register, PPI configuration register and extended PPI configuration
     /// registers.
-    pub icfgr: [u32; 6],
+    pub icfgr: [ReadPureWrite<u32>; 6],
     _reserved9: [u32; 58],
     /// Interrupt group modifier register 0.
-    pub igrpmodr0: u32,
+    pub igrpmodr0: ReadPureWrite<u32>,
     /// Interrupt group modifier registers for extended PPI range.
-    pub igrpmodr_e: [u32; 2],
+    pub igrpmodr_e: [ReadPureWrite<u32>; 2],
     _reserved10: [u32; 61],
     /// Non-secure access control register.
     pub nsacr: u32,

--- a/src/gicv3/registers.rs
+++ b/src/gicv3/registers.rs
@@ -295,6 +295,13 @@ bitflags! {
     }
 }
 
+/// GIC Redistributor, SGI and PPI registers.
+#[repr(C, align(8))]
+pub struct GicrSgi {
+    pub gicr: Gicr,
+    pub sgi: Sgi,
+}
+
 /// GIC Redistributor registers.
 #[repr(C, align(8))]
 pub struct Gicr {
@@ -435,5 +442,11 @@ mod tests {
         assert_eq!(Typer(1 << 11).num_lpis(), 4);
         assert_eq!(Typer(2 << 11).num_lpis(), 8);
         assert_eq!(Typer(16 << 11).num_lpis(), 1 << 17);
+    }
+
+    #[test]
+    fn gicr_size() {
+        // The size of the Gicr struct should match the offset from `RD_base` to `SGI_base`.
+        assert_eq!(size_of::<Gicr>(), 0x10000);
     }
 }


### PR DESCRIPTION
This doesn't change the public API other than the raw pointer methods, but reduces the number unsafe blocks.