### PR TITLE
Fix the number of bits programmed for SPIs

### DIFF
--- a/src/gicv3.rs
+++ b/src/gicv3.rs
@@ -169,7 +169,7 @@ impl GicV3<'_> {
             } else {
                 (1 << (max_reg - i)) - 1
             };
-            field!(self.gicd, igroupr).get(i).unwrap().write(bits);
+            field!(self.gicd, igroupr).get(i / 32).unwrap().write(bits);
         }
 
         // Enable group 1 for the current security state.


### PR DESCRIPTION
In the current initialization and interrupt enable routines, the code attempts to program all SPIs from 32 up to 1024 unconditionally.

However, since the upper 32 lines may not always be implemented, programming them can lead to unexpected behavior or trigger a SYN_SPI_BLOCK error if RAS is enabled.

This update refines the logic to first check the number of supported SPIs and only program up to the corresponding bit offsets.

The change has been tested on QEMU virtual platform and booted to UEFI shell environment.

Fixes https://github.com/google/arm-gic/issues/67.